### PR TITLE
Expose 'immediate' parameter for debounce

### DIFF
--- a/addon/components/hyper-search.js
+++ b/addon/components/hyper-search.js
@@ -30,6 +30,7 @@ export default Component.extend({
   layout,
   minQueryLength: 3,
   debounceRate: 0,
+  debounceAfter: true,
   endpoint: null,
   resultKey: null,
   placeholder: null,
@@ -122,7 +123,7 @@ export default Component.extend({
 
   actions: {
     search(_event, query) {
-      debounce(this, '_search', query, get(this, 'debounceRate'), true);
+      debounce(this, '_search', query, get(this, 'debounceRate'), get(this, 'debounceAfter'));
     },
 
     selectResult(result) {


### PR DESCRIPTION
In some cases, users will expect a search query to run after they've stopped typing. In order to enable this behavior as an option, a `debounceAfter` property is added that defaults to true, but can be set to false.

Per the Ember.run docs (http://emberjs.com/api/classes/Ember.run.html#method_debounce), the last parameter of `debounce()` causes the method to be run immediately, with subsequent calls to the same method blocked until the specified time period expires.

The property name `debounceAfter` is admittedly not great, but I'm not sure what's better.
